### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,6 +14,10 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+  dependencies: write
+
 jobs:
   build:
 

--- a/.github/workflows/myFlow.yml
+++ b/.github/workflows/myFlow.yml
@@ -14,6 +14,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,10 @@ on:
   pull_request:
     branches: [ "main" ]
   workflow_dispatch:
- 
+
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/IGE-112244/Battleship2/security/code-scanning/10](https://github.com/IGE-112244/Battleship2/security/code-scanning/10)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege token scopes by default.

Best fix here (without changing behavior): in `.github/workflows/tests.yml`, insert:

```yml
permissions:
  contents: read
```

right after the trigger section (`on:` block) and before `jobs:`. This is sufficient for the current steps (`actions/checkout`, Maven test run, and artifact upload), and it satisfies CodeQL’s recommendation for a minimal safe baseline. No imports, methods, or other definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
