### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CloseIssue.yml
+++ b/.github/workflows/CloseIssue.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [closed]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/IGE-112244/Battleship2/security/code-scanning/1](https://github.com/IGE-112244/Battleship2/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/CloseIssue.yml` at the workflow root so all jobs inherit it. For this workflow, the minimal safe baseline is:

- `contents: read`

This preserves current functionality (checkout + build/test/docs generation) while preventing unintended write scopes on `GITHUB_TOKEN`. No imports, methods, or dependencies are needed—just YAML configuration in this single file near the top-level keys (`name`, `on`, `jobs`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
