### PR TITLE
Fix: Workflow does not contain permissions - alertas #3, #4, #5, #6

### DIFF
--- a/.github/workflows/SonarCloudQualityGateCheck.yml
+++ b/.github/workflows/SonarCloudQualityGateCheck.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   sonarcloud-quality-gate:
     name: SonarCloud Quality Gate Check

--- a/.github/workflows/data-class-detection.yml
+++ b/.github/workflows/data-class-detection.yml
@@ -3,6 +3,8 @@
 # Critério: WOC < 0.33 e NOPA >= 3 e NOAM >= 3 (Object-Oriented Metrics in Practice, Lanza & Marinescu)
 # Ferramenta: Qodana for JVM
 name: Data Class Detection - Quality Gate
+permissions:
+  contents: read
 on:
   push:
     branches: [ main, master ]

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,5 +1,8 @@
 name: Build and Push Docker Image
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/long-method-detection.yml
+++ b/.github/workflows/long-method-detection.yml
@@ -6,6 +6,9 @@
 
 name: Long Method Detection - Quality Gate
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, master ]


### PR DESCRIPTION
Potential fix for [https://github.com/IGE-112244/Battleship2/security/code-scanning/3](https://github.com/IGE-112244/Battleship2/security/code-scanning/3)

Add an explicit `permissions` block at the workflow root so all jobs inherit minimal token scopes by default.

Best fix here (without changing behavior): in `.github/workflows/data-class-detection.yml`, insert:

```yml
permissions:
  contents: read
```

right after the workflow `name` (before `on:`).  
This satisfies CodeQL’s minimal recommendation and keeps current functionality intact (checkout and artifact upload do not require `contents: write`). No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
