### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/myFlow.yml
+++ b/.github/workflows/myFlow.yml
@@ -14,6 +14,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/IGE-112244/Battleship2/security/code-scanning/7](https://github.com/IGE-112244/Battleship2/security/code-scanning/7)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged.  
Best fix here (without changing behavior): define workflow-level permissions with `contents: read`, since all current jobs only need repository read access (checkout/build/docs generation). This applies to all jobs unless overridden later.

**File/region to change**: `.github/workflows/myFlow.yml`, near the top-level keys (after `on:` block and before `jobs:` is the clearest placement).

No imports, methods, or dependencies are needed—just YAML key insertion.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
