### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,6 +14,10 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+  dependencies: write
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/IGE-112244/Battleship2/security/code-scanning/8](https://github.com/IGE-112244/Battleship2/security/code-scanning/8)

Add an explicit `permissions` block at the workflow root (best here since there is only one job), so all jobs inherit least-privilege defaults.  
For this workflow, set:

- `contents: read` (needed by `actions/checkout`)
- `dependencies: write` (needed for dependency submission action)

This preserves existing functionality while restricting token access compared to unspecified defaults.  
Edit only `.github/workflows/maven.yml`, inserting the `permissions` block after the `on:` trigger section and before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
