### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/BuildTest.yml
+++ b/.github/workflows/BuildTest.yml
@@ -14,6 +14,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/IGE-112244/Battleship2/security/code-scanning/2](https://github.com/IGE-112244/Battleship2/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root so it applies to all jobs (including `build`) unless overridden. For this workflow, the minimal required permission is:

- `contents: read` (needed by `actions/checkout` to read repository contents)

This preserves existing behavior while enforcing least privilege and preventing accidental permission expansion if repo/org defaults change.

Edit `.github/workflows/BuildTest.yml` by inserting `permissions:` between the trigger (`on:` block) and `jobs:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
