### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonarqube-analysis.yml
+++ b/.github/workflows/sonarqube-analysis.yml
@@ -11,6 +11,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   sonarqube-analysis:
     name: SonarQube Quality Analysis


### PR DESCRIPTION
Potential fix for [https://github.com/IGE-112244/Battleship2/security/code-scanning/9](https://github.com/IGE-112244/Battleship2/security/code-scanning/9)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained regardless of repository/org defaults.  
Best fix here: define workflow-level permissions right after `on:` (or before `jobs:`), applying to all jobs in this workflow.

For this Sonar analysis workflow, a safe minimal baseline is:

- `contents: read`

This allows repository checkout and read access to code while preventing unnecessary write scopes. No imports, methods, or dependencies are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
